### PR TITLE
Add wrapper functions and tests

### DIFF
--- a/src/safestructures/__init__.py
+++ b/src/safestructures/__init__.py
@@ -1,8 +1,8 @@
 from importlib import metadata
 
 from safestructures.processors.base import DataProcessor, TensorProcessor
-from safestructures.serializer import Serializer
+from safestructures.wrapper import load_file, save_file
 
 __version__ = metadata.version("safestructures")
 
-__all__ = ["Serializer", "DataProcessor", "TensorProcessor"]
+__all__ = ["save_file", "load_file", "DataProcessor", "TensorProcessor"]

--- a/src/safestructures/processors/base.py
+++ b/src/safestructures/processors/base.py
@@ -10,7 +10,7 @@ from safestructures.constants import Mode, TYPE_FIELD, VALUE_FIELD
 from safestructures.utils.module import get_import_path
 
 if TYPE_CHECKING:
-    from safestructures import Serializer
+    from safestructures.serializer import Serializer
 
 
 class DataProcessor(ABC):

--- a/src/safestructures/serializer.py
+++ b/src/safestructures/serializer.py
@@ -72,7 +72,7 @@ class Serializer:
             f"{plugin} must be a safestructures.DataProcessor"
             " or safestructures.TensorProcessor"
         )
-        assert isinstance(plugin, DataProcessor), error_msg
+        assert issubclass(plugin, DataProcessor), error_msg
 
         if plugin.data_type in self.process_map:
             error_msg = (

--- a/src/safestructures/wrapper.py
+++ b/src/safestructures/wrapper.py
@@ -1,0 +1,71 @@
+"""Wrapper functions for end-users."""
+
+from pathlib import PosixPath
+from typing import Any, Optional, Union
+
+from safestructures.processors.base import DataProcessor, TensorProcessor
+from safestructures.serializer import Serializer
+
+BASE_PROCESSORS = (TensorProcessor, DataProcessor)
+PROCESSOR_TYPES = Union[TensorProcessor, DataProcessor]
+
+
+def save_file(
+    data: Any,
+    save_path: Union[str, PosixPath],
+    metadata: Optional[dict[str, str]] = None,
+    plugins: Optional[Union[PROCESSOR_TYPES, list[PROCESSOR_TYPES]]] = None,
+):
+    """Save data using Safestructures.
+
+    Args:
+        data (Any): Data to save.
+            Data must use data types that are serializable
+            by Safetensors/Safestructures.
+        save_path (Union[str, PosixPath]): Path to save the data.
+            Directory must already exist.
+        metadata (Optional[dict[str, str]], optional): Additional metadata to save.
+            Defaults to None for no metadata.
+        plugins (Optional[Union[PROCESSOR_TYPES, list[PROCESSOR_TYPES]]], optional):
+            Additional plugins to serialize data for data types not covered
+            by safestructures. Defaults to None for no plugins.
+
+    Returns:
+        None.
+    """
+    if plugins is not None and issubclass(plugins, BASE_PROCESSORS):
+        plugins = [plugins]
+
+    return Serializer(plugins=plugins).save(data, save_path, metadata=metadata)
+
+
+def load_file(
+    load_path: Union[str, PosixPath],
+    framework: str = "np",
+    device: str = "cpu",
+    plugins: Optional[Union[PROCESSOR_TYPES, list[PROCESSOR_TYPES]]] = None,
+):
+    """Load data using Safestructures.
+
+    The file must be a valid Safestructures file,
+    i.e Safetensors file with additional Safestructures metadata.
+
+    Args:
+        load_path (Union[str, PosixPath]): Path to a valid Safestructures file.
+        framework (str, optional): The framework to load tensors into.
+            Defaults to "np" for Numpy.
+        device (str, optional): Device to allocate tensors to.
+            Defaults to "cpu" to allocate on CPU.
+        plugins (Optional[Union[PROCESSOR_TYPES, list[PROCESSOR_TYPES]]], optional):
+            Additional plugins to serialize data for data types not covered
+            by safestructures. Defaults to None for no plugins.
+
+    Returns:
+        The loaded data.
+    """
+    if plugins is not None and issubclass(plugins, BASE_PROCESSORS):
+        plugins = [plugins]
+
+    return Serializer(plugins=plugins).load(
+        load_path, framework=framework, device=device
+    )

--- a/tests/test_iterable.py
+++ b/tests/test_iterable.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 import pytest
 
-from safestructures import Serializer
 from safestructures.constants import KEYS_FIELD, Mode, TYPE_FIELD, VALUE_FIELD
 from safestructures.processors.iterable import (
     DataclassProcessor,
@@ -14,6 +13,7 @@ from safestructures.processors.iterable import (
     SetProcessor,
     TupleProcessor,
 )
+from safestructures.serializer import Serializer
 
 
 @pytest.fixture

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -8,8 +8,9 @@ import pytest
 import torch
 from utils import compare_nested_schemas, compare_values
 
-from safestructures import Serializer
+from safestructures import load_file, save_file
 from safestructures.constants import KEYS_FIELD, Mode, TYPE_FIELD, VALUE_FIELD
+from safestructures.serializer import Serializer
 
 FRAMEWORKS = ["np", "pt"]
 
@@ -306,4 +307,17 @@ def test_serializer_save_load(
     test_other_metadata = {"test_field": "test_value"}
     Serializer().save(test_input, test_file, metadata=test_other_metadata)
     loaded = Serializer().load(test_file, framework=framework)
+    compare_values(test_input, loaded)
+
+
+@pytest.mark.parametrize("framework", FRAMEWORKS)
+@pytest.mark.parametrize("test_input,expected_schema,native_tensor_fn", TEST_CASES)
+def test_wrapper_save_load(
+    tmp_path, test_input, expected_schema, native_tensor_fn, framework
+):
+    """Integration test for the wrapper `save_file` and `load_file` functions."""
+    test_file = tmp_path / "Test.safetensors"
+    test_other_metadata = {"test_field": "test_value"}
+    save_file(test_input, test_file, metadata=test_other_metadata)
+    loaded = load_file(test_file, framework=framework)
     compare_values(test_input, loaded)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -8,7 +8,6 @@ import torch
 from safetensors import safe_open
 from safetensors.numpy import save_file
 
-from safestructures import Serializer
 from safestructures.constants import (
     SCHEMA_FIELD,
     SCHEMA_VERSION,
@@ -17,6 +16,7 @@ from safestructures.constants import (
     VERSION_FIELD,
 )
 from safestructures.defaults import DEFAULT_PROCESS_MAP
+from safestructures.serializer import Serializer
 
 MOCK_DEFAULT_PROCESS_MAP = {
     data_type: mock.MagicMock() for data_type in DEFAULT_PROCESS_MAP

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -6,9 +6,9 @@ import numpy as np
 import pytest
 import torch
 
-from safestructures import Serializer
 from safestructures.processors.base import TensorProcessor
 from safestructures.processors.tensor import NumpyProcessor, TorchProcessor
+from safestructures.serializer import Serializer
 
 
 @pytest.fixture

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,57 @@
+"""Test the wrapper functions."""
+from unittest import mock
+
+from safestructures import DataProcessor, load_file, save_file
+
+
+class MockPlugin(DataProcessor):
+    """Mock plugin."""
+
+    data_type = mock.Mock
+
+    def serialize(self, data):
+        """Overload `DataProcessor.serialize`."""
+        pass
+
+    def deserialize(self, serialized):
+        """Overload `DataProcessor.deserialize`."""
+        pass
+
+
+def test_save_file():
+    """Test the `save_file` wrapper function."""
+    mock_input = mock.Mock()
+    mock_save_path = "path/to/save.safetensors"
+    mock_metadata = {"mock_field": "mock_value"}
+    mock_serializer_instance = mock.MagicMock()
+    mock_serializer = mock.MagicMock(return_value=mock_serializer_instance)
+
+    with mock.patch("safestructures.wrapper.Serializer", mock_serializer):
+        save_file(
+            mock_input, mock_save_path, metadata=mock_metadata, plugins=MockPlugin
+        )
+        mock_serializer.assert_called_once_with(plugins=[MockPlugin])
+        mock_serializer_instance.save.assert_called_once_with(
+            mock_input, mock_save_path, metadata=mock_metadata
+        )
+
+
+def test_load_file():
+    """Test the `load_file` wrapper function."""
+    mock_load_path = "path/to/save.safetensors"
+    mock_framework = "mock_framework"
+    mock_device = "mock_device"
+    mock_serializer_instance = mock.MagicMock()
+    mock_serializer = mock.MagicMock(return_value=mock_serializer_instance)
+
+    with mock.patch("safestructures.wrapper.Serializer", mock_serializer):
+        load_file(
+            mock_load_path,
+            framework=mock_framework,
+            device=mock_device,
+            plugins=MockPlugin,
+        )
+        mock_serializer.assert_called_once_with(plugins=[MockPlugin])
+        mock_serializer_instance.load.assert_called_once_with(
+            mock_load_path, framework=mock_framework, device=mock_device
+        )


### PR DESCRIPTION
# Summary
* Adds `save_file` and `load_file` wrapper functions so users do not need to instantiate `Serializer`
* Removes `Serializer` from root import
* Adds additional unit tests to test the wrapper functions.

# Tests
See CI tests.
