### PR TITLE
Adding test release workflows

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,0 +1,21 @@
+name: Build and Deploy Docs
+on:
+  workflow_call:
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.10
+
+    steps:
+      - name: Get safestructures
+        uses: actions/checkout@v4
+
+      - name: Install safestructures with docs dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -e ".[docs]"
+
+      - name: Deploy to Github pages
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - release/**
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,22 +34,3 @@ jobs:
           pip install .[test]
       - name: Test safestructures
         run: pytest tests
-
-  # deploy-docs:
-  #   needs: pytest
-
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: python:3.10
-
-  #   steps:
-  #     - name: Get safestructures
-  #       uses: actions/checkout@v4
-
-  #     - name: Install safestructures with docs dependencies
-  #       run: |
-  #         pip install --upgrade pip
-  #         pip install -e ".[docs]"
-
-  #     - name: deploy-to-gh-pages
-  #       run: mkdocs gh-deploy --force

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: Release Actions
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  ci-tests:
+    name: Run CI tests
+    uses: .github/workflows/ci_tests.yaml
+
+  deploy-docs:
+    name: Deploy docs
+    needs: ci-tests
+    uses: .github/workflows/build_docs.yaml
+
+  release:
+    name: Build and release pip package
+    needs: deploy-docs
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.11"
+    - name: Get safestructures
+      uses: actions/checkout@master
+    - name: Setup
+      run: |
+        pip install wheel build twine
+    - name: Build distribution
+      run: |
+        python -m build
+    - name: Create pre-release draft
+      uses: softprops/action-gh-release@v0.1.14
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        name: Release ${{ github.ref_name }}
+        draft: true
+        prerelease: true
+        files: |
+          ${{github.workspace}}/dist/*
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TEST }}
+      run: |
+        twine upload -r testpypi dist/*


### PR DESCRIPTION
# Summary
* Adjust CI tests workflow to also be callable by other workflows
* Adds callable doc build and deploy workflow
* Adds release workflow with test release to TestPyPI

# Tests
See CI tests, otherwise will need to tests tags manually.
