### PR TITLE
Bump to official 1.0.0 version, use real PyPI index

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
     - name: Publish to PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TEST }}
+        TWINE_PASSWORD: ${{ secrets.PYPI }}
       run: |
-        twine upload -r testpypi dist/*
+        twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "safestructures"
-version = "0.1.0"
+version = "1.0.0"
 description = "Safetensors-based serialization of general data structures"
 authors = [
     {name = "Craig Chan"}


### PR DESCRIPTION
# Summary
* Bumps version to official 1.0.0! Release is imminent.
* Use the real PyPI index to publish package. 

# Tests
Used Test PyPI index, and saw it published: https://test.pypi.org/project/safestructures/
